### PR TITLE
Allow links to work and make them launch in an external browser.

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -1,6 +1,6 @@
 from setuptools import setup, find_packages
 
-__version__ = "0.6.0"
+__version__ = "0.6.1"
 __author__ = "DavidCEllis"
 
 

--- a/src/splitnotes2/note_parser.py
+++ b/src/splitnotes2/note_parser.py
@@ -10,6 +10,7 @@ import markdown
 
 
 PERMITTED_TAGS = [
+    "p",
     "br",
     "del",
     "ins",
@@ -30,7 +31,7 @@ PERMITTED_TAGS = [
 ]
 
 PERMITTED_ATTRIBUTES = {
-    "*": ["class", "style"],
+    "*": ["class", "style", "href"],
     "img": ["src", "alt", "width", "height"],
     "video": [
         "autoplay",

--- a/src/splitnotes2/ui/custom_elements/__init__.py
+++ b/src/splitnotes2/ui/custom_elements/__init__.py
@@ -1,0 +1,1 @@
+from .webenginepage import ExtLinkWebEnginePage

--- a/src/splitnotes2/ui/custom_elements/webenginepage.py
+++ b/src/splitnotes2/ui/custom_elements/webenginepage.py
@@ -1,0 +1,18 @@
+"""
+Replace the standard QWebEnginePage with one that launches links in the user's default browser
+"""
+from PySide2.QtWebEngineWidgets import QWebEnginePage
+from PySide2.QtGui import QDesktopServices
+
+
+class ExtLinkWebEnginePage(QWebEnginePage):
+    """
+    QWebEnginePage that launches links in an external browser
+    """
+
+    def acceptNavigationRequest(self, url, _type, is_mainframe):
+        # Launch external browser for clicking links, otherwise do default behaviour
+        if _type == QWebEnginePage.NavigationTypeLinkClicked:
+            QDesktopServices.openUrl(url)
+            return False
+        return super().acceptNavigationRequest(url, _type, is_mainframe)

--- a/src/splitnotes2/ui/main_window.py
+++ b/src/splitnotes2/ui/main_window.py
@@ -7,6 +7,7 @@ from jinja2 import Environment, FileSystemLoader
 from PySide2 import QtCore
 from PySide2.QtGui import QCursor, QIcon
 from PySide2.QtWidgets import QMainWindow, QFileDialog, QMenu
+from .custom_elements import ExtLinkWebEnginePage
 
 from ..settings import Settings
 from .settings_ui import SettingsDialog
@@ -158,9 +159,12 @@ class MainWindow(QMainWindow):
         event.accept()
 
     def setup_actions(self):
-        """Make the context menu for the UI the custom menu."""
+        """Setup the browser element with custom options"""
+        # Replace the context menu with the app context menu
         self.ui.notes.setContextMenuPolicy(QtCore.Qt.CustomContextMenu)
         self.ui.notes.customContextMenuRequested.connect(self.show_menu)
+        # Allow links to open in an external browser
+        self.ui.notes.setPage(ExtLinkWebEnginePage(self))
 
     def build_menu(self):
         """Create the custom context menu."""


### PR DESCRIPTION
Links made either in HTML or Markdown now work and launch the user's default browser when clicked.